### PR TITLE
Don't enforce user management, use the correct command to run the process

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 gitlab_pipelines_exporter_architecture: 'linux_amd64'
 gitlab_pipelines_exporter_version: '0.4.4'
 
+gitlab_pipelines_exporter_ensure_prometheus_user: false
+
 gitlab_verify_ssl: 'true'
 
 gitlab_pipelines_exporter_download_url: 'https://github.com/mvisonneau/gitlab-ci-pipelines-exporter/releases/download/v{{ gitlab_pipelines_exporter_version }}/gitlab-ci-pipelines-exporter_v{{ gitlab_pipelines_exporter_version }}_{{ gitlab_pipelines_exporter_architecture }}.tar.gz'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,17 +1,21 @@
 ---
-- name: Ensure group for prometheus user exists
-  group:
-    name: '{{ gitlab_pipelines_exporter_group }}'
-    state: present
+- block:
 
-- name: Add user prometheus user
-  user:
-    name: '{{ gitlab_pipelines_exporter_user }}'
-    home: '{{ gitlab_pipelines_exporter_user_home }}'
-    group: '{{ gitlab_pipelines_exporter_group }}'
-    shell: '{{ gitlab_pipelines_exporter_user_shell }}'
-    state: present
+  - name: Ensure group for prometheus user exists
+    group:
+      name: '{{ gitlab_pipelines_exporter_group }}'
+      state: present
 
+  - name: Add user prometheus user
+    user:
+      name: '{{ gitlab_pipelines_exporter_user }}'
+      home: '{{ gitlab_pipelines_exporter_user_home }}'
+      group: '{{ gitlab_pipelines_exporter_group }}'
+      shell: '{{ gitlab_pipelines_exporter_user_shell }}'
+      state: present
+      
+  when: gitlab_pipelines_exporter_ensure_prometheus_user
+  
 - name: Create gitlab_pipelines_exporter directory
   file:
     path: '{{ gitlab_pipelines_exporter_install_path }}'

--- a/templates/gitlab_pipelines_exporter.service.j2
+++ b/templates/gitlab_pipelines_exporter.service.j2
@@ -8,7 +8,7 @@ After=network.target
 Wants=network.target
 
 [Service]
-ExecStart={{ gitlab_pipelines_exporter_install_path }}/gitlab-ci-pipelines-exporter --config {{ gitlab_pipelines_exporter_config_path }}/config.yml
+ExecStart={{ gitlab_pipelines_exporter_install_path }}/gitlab-ci-pipelines-exporter run --config {{ gitlab_pipelines_exporter_config_path }}/config.yml
 Restart=always
 RestartSec=20
 TimeoutSec=300


### PR DESCRIPTION
The summary of changes

* Prometheus user is best handled by Prometheus itself probably, so this feature should be disabled by default
* Gitlab exporter's syntax must have changed in the later versions - since the inception of this role - so that one had too be tweaked. Tbh the ideal outcome would be to probably have this one even more steere-able, but I'll leave this one open because 🤷🏾 